### PR TITLE
upload to s3 rake task; change 'dist' output to list-view*.js

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -1,14 +1,12 @@
 instance_eval File.read(EmberDev.support_path.join('Assetfile'))
 
 distros = {
-  :full    => %w(list-view)
+  "list-view" => %w(list-view)
 }
 
 output "dist"
 
 distros.each do |name, modules|
-  name = "ember-dev-package"
-
   input "dist/modules" do
     module_paths = modules.map{|m| "#{m}.js" }
     match "{#{module_paths.join(',')}}" do

--- a/Rakefile
+++ b/Rakefile
@@ -25,8 +25,18 @@ file "packages/ember/lib/main.js" => [:update_ember_git, "tmp/ember.js/dist/embe
   end
 end
 
-task :update_ember => "packages/ember/lib/main.js"
+task :publish_build do
+  root = File.dirname(__FILE__) + '/dist/'
+  EmberDev::Publish.to_s3({
+    :access_key_id => ENV['S3_ACCESS_KEY_ID'],
+    :secret_access_key => ENV['S3_SECRET_ACCESS_KEY'],
+    :bucket_name => ENV['S3_BUCKET_NAME'],
+    :subdirectory => 'list-view',
+    :files => ['list-view.js'].map { |f| root + f }
+  })
+end
 
+task :update_ember => "packages/ember/lib/main.js"
 
 task :clean => "ember:clean"
 task :dist => "ember:dist"


### PR DESCRIPTION
Before files in dist were being generated as ember-dev-package-_.js. Now
they are written as dist/list-view_.js, where the asterisk fills in
prod,min, etc.

We'll need to put the credentials in a .travis.yml file like in the ember data and ember.js repos
