### PR TITLE
Fix "defaultContainer is no longer supported" deprecation warning

### DIFF
--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -484,7 +484,7 @@ Ember.ListViewMixin = Ember.Mixin.create({
     var itemViewClass, childView;
 
     itemViewClass = get(this, 'itemViewClass');
-    childView = itemViewClass.create();
+    childView = this.createChildView(itemViewClass);
 
     this.pushObject(childView);
    },


### PR DESCRIPTION
Fixes `Using the defaultContainer is no longer supported. [defaultContainer#lookup]` deprecation warning

The fix is based on https://gist.github.com/stefanpenner/5627411 and modelled after similar fix to ember-table: https://github.com/addepar/ember-table/commit/1fd29fdb2ae5283a7664f83789cc6b3550a5eb3c
