### PR TITLE
define Ember.ListViewMixin.emptyViewClass

### DIFF
--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -81,6 +81,7 @@ function enableProfilingOutput() {
 */
 Ember.ListViewMixin = Ember.Mixin.create({
   itemViewClass: Ember.ListItemView,
+  emptyViewClass: Ember.View,
   classNames: ['ember-list-view'],
   attributeBindings: ['style'],
   domManager: domManager,


### PR DESCRIPTION
Needed by the `collection` helper; would ordinarily be provided by `CollectionView`.
