### PR TITLE
[FIX] Avoid scroll event to propagate if it did scroll

### DIFF
--- a/packages/list-view/lib/virtual_list_view.js
+++ b/packages/list-view/lib/virtual_list_view.js
@@ -175,6 +175,7 @@ Ember.VirtualListView = Ember.ContainerView.extend(Ember.ListViewMixin, Ember.Vi
 
     if ((candidatePosition >= 0) && (candidatePosition <= this.scroller.__maxScrollTop)) {
       this.scroller.scrollBy(0, delta, true);
+      e.stopPropagation();
     }
 
     return false;


### PR DESCRIPTION
When the list view is in a scrollable container, the scroll event should not be propagated if it has been handled by the list view.
