### PR TITLE
failing test for replacing list content after scrolling

### DIFF
--- a/packages/list-view/tests/content_tests.js
+++ b/packages/list-view/tests/content_tests.js
@@ -220,7 +220,7 @@ test("replacing the list content after scrolling to the middle", function() {
   deepEqual(helper.itemPositions(view), [
               { x: 0, y: 0 },
               { x: 0, y: 50 },
-              { x: 0, y: 150 }], "The rows are in the correct positions");
+              { x: 0, y: 100 }], "The rows are in the correct positions");
   equal(view.$('.ember-list-item-view:visible').length, 3, "The number of items that are not hidden with display:none");
 });
 


### PR DESCRIPTION
The issue is demonstrated here: http://jsbin.com/ebUjAkEW/4/

Do some scrolling and click change content. Planning to investigate further to find the source of problem.
