### PR TITLE
Allow fluid width override & protect against a width smaller than elementWidth

### DIFF
--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -38,18 +38,7 @@ domManager.prepend = function(view, html) {
   notifyMutationListeners();
 };
 
-function syncListContainerWidth(){
-  var elementWidth, columnCount, containerWidth, element;
 
-  elementWidth = get(this, 'elementWidth');
-  columnCount = get(this, 'columnCount');
-  containerWidth = elementWidth * columnCount;
-  element = this.$('.ember-list-container');
-
-  if (containerWidth && element) {
-    element.css('width', containerWidth);
-  }
-}
 
 function enableProfilingOutput() {
   function before(name, time, payload) {
@@ -98,7 +87,7 @@ Ember.ListViewMixin = Ember.Mixin.create({
   */
   init: function() {
     this._super();
-    this.on('didInsertElement', syncListContainerWidth);
+    this.on('didInsertElement', this._syncListContainerWidth);
     this.columnCountDidChange();
     this._syncChildViews();
     this._addContentArrayObserver();
@@ -347,7 +336,7 @@ Ember.ListViewMixin = Ember.Mixin.create({
     elementWidth = get(this, 'elementWidth');
     width = get(this, 'width');
 
-    if (elementWidth) {
+    if (elementWidth && width > elementWidth) {
       count = floor(width / elementWidth);
     } else {
       count = 1;
@@ -387,7 +376,7 @@ Ember.ListViewMixin = Ember.Mixin.create({
 
     if (arguments.length > 0) {
       // invoked by observer
-      Ember.run.schedule('afterRender', this, syncListContainerWidth);
+      Ember.run.schedule('afterRender', this, this._syncListContainerWidth);
     }
   }, 'columnCount'),
 
@@ -556,6 +545,26 @@ Ember.ListViewMixin = Ember.Mixin.create({
 
     this._lastStartingIndex = startingIndex;
     this._lastEndingIndex   = this._lastEndingIndex + delta;
+  },
+
+  /**
+    @private
+
+    Applies an inline width style to the list container.
+
+    @method _syncListContainerWidth
+   **/
+  _syncListContainerWidth: function(){
+    var elementWidth, columnCount, containerWidth, element;
+
+    elementWidth = get(this, 'elementWidth');
+    columnCount = get(this, 'columnCount');
+    containerWidth = elementWidth * columnCount;
+    element = this.$('.ember-list-container');
+
+    if (containerWidth && element) {
+      element.css('width', containerWidth);
+    }
   },
 
   /**

--- a/packages/list-view/tests/list_view_test.js
+++ b/packages/list-view/tests/list_view_test.js
@@ -627,6 +627,27 @@ test("elementWidth change", function(){
     equal(Ember.$(positionSorted[i]).text(), "Item " + (i+1));
   }
 
+  // Test a width smaller than elementWidth, should behave the same as width === elementWidth
+  Ember.run(function () {
+    view.set('width', 50);
+  });
+
+  equal(view.$('.ember-list-item-view').length, 5, "The correct number of rows were rendered");
+
+  positionSorted = helper.sortElementsByPosition(view.$('.ember-list-item-view'));
+
+  deepEqual(helper.itemPositions(view), [
+            { x: 0, y: 0},
+            { x: 0, y: 50},
+            { x: 0, y: 100},
+            { x: 0, y: 150},
+            { x: 0, y: 200}
+  ], "The rows are in the correct positions");
+
+  for(i = 0; i < 5; i++) {
+    equal(Ember.$(positionSorted[i]).text(), "Item " + (i+1));
+  }
+
   Ember.run(function() {
     view.set('width', 200);
   });


### PR DESCRIPTION
I created a subclass of Ember.ListView that is fluid/responsive. The grid items expand to fill the row until there's enough room for the next column, and the width and height of the list dynamically update as you resize the browser.

In order to efficiently achieve this useful subclass, however, `syncListContainerWidth` needs to be overridable. This pull request provides the private `_syncListContainerWidth` for override, as well as ensuring that a list with a current width less than the elementWidth won't lead to divide by 0 js errors. I've added tests for the latter.
