### PR TITLE
Add emptyView support.

### DIFF
--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -38,6 +38,25 @@ function removeEmptyView() {
   }
 }
 
+function addEmptyView() {
+  var emptyView = get(this, 'emptyView');
+
+  if (!emptyView) { return; }
+
+  if ('string' === typeof emptyView) {
+    emptyView = get(emptyView) || emptyView;
+  }
+
+  emptyView = this.createChildView(emptyView);
+  set(this, 'emptyView', emptyView);
+
+  if (Ember.CoreView.detect(emptyView)) {
+    this._createdEmptyView = emptyView;
+  }
+
+  this.unshiftObject(emptyView);
+}
+
 var domManager = Ember.create(Ember.ContainerView.proto().domManager);
 
 domManager.prepend = function(view, html) {
@@ -519,12 +538,15 @@ Ember.ListViewMixin = Ember.Mixin.create({
       return;
     }
 
-    removeEmptyView.call(this);
-
     contentLength = get(this, 'content.length');
+    emptyView = get(this, 'emptyView');
 
     childViewCount = this._childViewCount();
     childViews = this.positionOrderedChildViews();
+
+    if (childViews.indexOf(emptyView) === 0) {
+      removeEmptyView.call(this);
+    }
 
     startingIndex = this._startingIndex();
     endingIndex = startingIndex + childViewCount;
@@ -543,7 +565,6 @@ Ember.ListViewMixin = Ember.Mixin.create({
       for (count = 0; count < delta; count++, contentIndex++) {
         this._addItemView(contentIndex);
       }
-
     } else {
       // less views are needed
       forEach.call(
@@ -558,22 +579,8 @@ Ember.ListViewMixin = Ember.Mixin.create({
     this._lastStartingIndex = startingIndex;
     this._lastEndingIndex   = this._lastEndingIndex + delta;
 
-    if (!contentLength) {
-      emptyView = get(this, 'emptyView');
-
-      if (!emptyView) { return; }
-
-      if ('string' === typeof emptyView) {
-        emptyView = get(emptyView) || emptyView;
-      }
-
-      emptyView = this.createChildView(emptyView);
-      set(this, 'emptyView', emptyView);
-
-      if (Ember.CoreView.detect(emptyView)) {
-        this._createdEmptyView = emptyView;
-      }
-      this.unshiftObject(emptyView);
+    if (contentLength === 0 || contentLength === undefined) {
+      addEmptyView.call(this);
     }
   },
 

--- a/packages/list-view/tests/list_view_test.js
+++ b/packages/list-view/tests/list_view_test.js
@@ -79,6 +79,16 @@ test("should render an empty view when there is no content", function() {
 
   equal(view.$('.ember-list-item-view').length, 10, "The correct number of rows were rendered");
   equal(view.$('.empty-view').length, 0, "The empty view is removed");
+
+  Ember.run(function () {
+    view.set('content', content);
+  });
+
+  equal(view.get('element').style.height, "500px", "The list view height is correct");
+  equal(view.$('.ember-list-container').height(), 0, "The scrollable view has the correct height");
+
+  equal(view.$('.ember-list-item-view').length, 0, "The correct number of rows were rendered");
+  equal(view.$('.empty-view').length, 1, "The empty view rendered");
 });
 
 test("should render a subset of the full content, based on the height, in the correct positions", function() {


### PR DESCRIPTION
This commit adds emptyView support, similar to the `Ember.CollectionView`, so the user can interface with the view as they might expect when subclassing. I also removed some unused variables.

Usage:

``` javascript
Ember.ListView.extend({
  emptyView: Ember.View.extend({
    template: Ember.Handlebars.compile("no items")
  })
});
```
