### PR TITLE
Make Ember.VirtualListScrollerEvents more versatile.

### DIFF
--- a/packages/list-view/lib/virtual_list_scroller_events.js
+++ b/packages/list-view/lib/virtual_list_scroller_events.js
@@ -105,7 +105,7 @@ Ember.VirtualListScrollerEvents = Ember.Mixin.create({
     };
     return this._super();
   },
-  scrollElement: Ember.computed.alias('element'),
+  scrollElement: Ember.computed.oneWay('element').readOnly(),
   bindScrollerEvents: function() {
     var el = this.get('scrollElement'),
       handlers = this.scrollerEventHandlers;


### PR DESCRIPTION
By abstracting the element that receives the bindings, we can allow users to use this mixin more creatively if needed. The default behavior will remain unchanged via the alias, but this allows for some versatility since most of the functionality here is hidden by scope.
