### PR TITLE
emptyView shouldn't be constrained by a container height.

### DIFF
--- a/packages/list-view/lib/list_view.js
+++ b/packages/list-view/lib/list_view.js
@@ -148,9 +148,18 @@ Ember.ListView = Ember.ContainerView.extend(Ember.ListViewMixin, {
   }, 'totalHeight'),
 
   _updateScrollableHeight: function () {
+    var height;
+
     if (this.state === 'inDOM') {
+      // if the list is currently displaying the emptyView, remove the height
+      if (this._isChildEmptyView()) {
+          height = '';
+      } else {
+          height = get(this, 'totalHeight');
+      }
+
       this.$('.ember-list-container').css({
-        height: get(this, 'totalHeight')
+        height: height
       });
     }
   }

--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -426,6 +426,20 @@ Ember.ListViewMixin = Ember.Mixin.create({
   /**
     @private
 
+    Determines whether the emptyView is the current childView.
+
+    @method _isChildEmptyView
+  */
+  _isChildEmptyView: function() {
+    var emptyView = get(this, 'emptyView');
+
+    return emptyView && emptyView instanceof Ember.View &&
+           this._childViews.length === 1 && this._childViews.indexOf(emptyView) === 0;
+  },
+
+  /**
+    @private
+
     Computes the number of views that would fit in the viewport area.
     You must specify `height` and `rowHeight` parameters for the number of
     views to be computed properly.
@@ -544,7 +558,7 @@ Ember.ListViewMixin = Ember.Mixin.create({
     childViewCount = this._childViewCount();
     childViews = this.positionOrderedChildViews();
 
-    if (childViews.indexOf(emptyView) === 0) {
+    if (this._isChildEmptyView()) {
       removeEmptyView.call(this);
     }
 

--- a/packages/list-view/tests/list_view_test.js
+++ b/packages/list-view/tests/list_view_test.js
@@ -47,11 +47,14 @@ test("should render an empty view when there is no content", function() {
   var content = helper.generateContent(0),
       height = 500,
       rowHeight = 50,
+      emptyViewHeight = 175,
       itemViewClass = Ember.ListItemView.extend({
         template: Ember.Handlebars.compile("{{name}}")
       }),
       emptyView = Ember.View.extend({
-        classNames: ['empty-view']
+        attributeBindings: ['style'],
+        classNames: ['empty-view'],
+        style: 'height:' + emptyViewHeight + 'px;'
       });
 
   view = Ember.ListView.create({
@@ -65,7 +68,7 @@ test("should render an empty view when there is no content", function() {
   appendView();
 
   equal(view.get('element').style.height, "500px", "The list view height is correct");
-  equal(view.$('.ember-list-container').height(), 0, "The scrollable view has the correct height");
+  equal(view.$('.ember-list-container').height(), emptyViewHeight, "The scrollable view has the correct height");
 
   equal(view.$('.ember-list-item-view').length, 0, "The correct number of rows were rendered");
   equal(view.$('.empty-view').length, 1, "The empty view rendered");
@@ -85,7 +88,7 @@ test("should render an empty view when there is no content", function() {
   });
 
   equal(view.get('element').style.height, "500px", "The list view height is correct");
-  equal(view.$('.ember-list-container').height(), 0, "The scrollable view has the correct height");
+  equal(view.$('.ember-list-container').height(), emptyViewHeight, "The scrollable view has the correct height");
 
   equal(view.$('.ember-list-item-view').length, 0, "The correct number of rows were rendered");
   equal(view.$('.empty-view').length, 1, "The empty view rendered");


### PR DESCRIPTION
After adding the emptyView, I missed the fact that the container still had a height of 0. When the emptyView is displaying the ember-list-container should have no inline height. Updated tests to account for this.

I added `_isChildEmptyView` to determine if the emptyView is actually the current child, which I am now using to determine if we need to remove the emptyView as well. This is an improvement over the check that was there before, since we will only run the more expensive `indexOf` when `emptyView` is an instance of `Ember.View` and the sole childView.
