### PR TITLE
Allow VirtualList synthesizeClick event to reach the target.

### DIFF
--- a/packages/list-view/lib/virtual_list_scroller_events.js
+++ b/packages/list-view/lib/virtual_list_scroller_events.js
@@ -129,7 +129,7 @@ function synthesizeClick(e) {
   var point = e.changedTouches[0],
     target = point.target,
     ev;
-  if (target && fieldRegex.test(target.tagName)) {
+  if (target) {
     ev = document.createEvent('MouseEvents');
     ev.initMouseEvent('click', true, true, e.view, 1, point.screenX, point.screenY, point.clientX, point.clientY, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey, 0, null);
     return target.dispatchEvent(ev);


### PR DESCRIPTION
I noticed none of my "click" events on my touch device were reaching their target. `synthesizeClick` was only allowing the events through if the target was a field. It seems like this was possibly a copy/paste isssue from the `touchstart` event handler.

If we get to the point where we are synthesizing a click, it's because we've reached `touchend` and the user was trying to tap on something in the list rather than scroll the list. So, we should allow that event to reach its intended target, otherwise the user won't be able to activate any links, ember actions, etc inside a VirtualList.