### PR TITLE
only show scrollbars if there is a need to scroll in firefox

### DIFF
--- a/packages/list-view/lib/list_view.js
+++ b/packages/list-view/lib/list_view.js
@@ -101,7 +101,7 @@ var get = Ember.get, set = Ember.set;
 Ember.ListView = Ember.ContainerView.extend(Ember.ListViewMixin, {
   css: {
     position: 'relative',
-    overflow: 'scroll',
+    overflow: 'auto',
     '-webkit-overflow-scrolling': 'touch',
     'overflow-scrolling': 'touch'
   },


### PR DESCRIPTION
Unsure if the overflow was intentionally set to scroll, but as it is both horizontal and vertical scrollbars show up regardless of whether there is a need to scroll. 

BEFORE
![image](https://f.cloud.github.com/assets/41799/2403121/e6821ee6-aa2a-11e3-94c8-f99e914f55e1.png)

![image](https://f.cloud.github.com/assets/41799/2403129/0dbc402c-aa2b-11e3-9e65-9e632a73735b.png)

AFTER
![image](https://f.cloud.github.com/assets/41799/2403106/cf443886-aa2a-11e3-8aba-807c87ed10e9.png)

![image](https://f.cloud.github.com/assets/41799/2403138/1f8d0a2a-aa2b-11e3-96cb-c2377443a214.png)
