### PR TITLE
Use view._state if available otherwise fall back to view.state

### DIFF
--- a/packages/list-view/lib/list_view.js
+++ b/packages/list-view/lib/list_view.js
@@ -148,9 +148,12 @@ Ember.ListView = Ember.ContainerView.extend(Ember.ListViewMixin, {
   }, 'totalHeight'),
 
   _updateScrollableHeight: function () {
-    var height;
+    var height, state;
 
-    if (this.state === 'inDOM') {
+    // Support old and new Ember versions
+    state = this._state || this.state;
+
+    if (state === 'inDOM') {
       // if the list is currently displaying the emptyView, remove the height
       if (this._isChildEmptyView()) {
           height = '';

--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -671,11 +671,14 @@ Ember.ListViewMixin = Ember.Mixin.create({
   */
   // TODO: refactor
   arrayDidChange: function(content, start, removedCount, addedCount) {
-    var index, contentIndex;
+    var index, contentIndex, state;
 
     removeEmptyView.call(this);
 
-    if (this.state === 'inDOM') {
+    // Support old and new Ember versions
+    state = this._state || this.state;
+
+    if (state === 'inDOM') {
       // ignore if all changes are out of the visible change
       if( start >= this._lastStartingIndex || start < this._lastEndingIndex) {
         index = 0;

--- a/packages/list-view/lib/reusable_list_item_view.js
+++ b/packages/list-view/lib/reusable_list_item_view.js
@@ -13,9 +13,13 @@ Ember.ReusableListItemView = Ember.View.extend(Ember.ListItemViewMixin, {
     return !!this.get('context.content');
   }),
   updateContext: function(newContext){
-    var context = get(this._proxyContext, 'content');
+    var context = get(this._proxyContext, 'content'), state;
+
+    // Support old and new Ember versions
+    state = this._state || this.state;
+
     if (context !== newContext) {
-      if (this.state === 'inDOM') {
+      if (state === 'inDOM') {
         this.prepareForReuse(newContext);
       }
 

--- a/packages/list-view/lib/virtual_list_view.js
+++ b/packages/list-view/lib/virtual_list_view.js
@@ -46,7 +46,10 @@ Ember.VirtualListView = Ember.ContainerView.extend(Ember.ListViewMixin, Ember.Vi
     view = this;
 
     view.scroller = new Scroller(function(left, top, zoom) {
-      if (view.state !== 'inDOM') { return; }
+      // Support old and new Ember versions
+      var state = view._state || view.state;
+
+      if (state !== 'inDOM') { return; }
 
       if (view.listContainerElement) {
         view._scrollerTop = top;


### PR DESCRIPTION
Fixes #127
