### PR TITLE
Fixed: made it possible to use absolute positioning

### DIFF
--- a/packages/list-view/lib/list_view.js
+++ b/packages/list-view/lib/list_view.js
@@ -157,6 +157,8 @@ Ember.ListView = Ember.ContainerView.extend(Ember.ListViewMixin, {
       // if the list is currently displaying the emptyView, remove the height
       if (this._isChildEmptyView()) {
           height = '';
+      } else if (this.get('css.position') === 'absolute') {
+          height = '';
       } else {
           height = get(this, 'totalHeight');
       }

--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -170,8 +170,10 @@ Ember.ListViewMixin = Ember.Mixin.create({
 
     style = '';
 
-    if (height) { style += 'height:' + height + 'px;'; }
-    if (width)  { style += 'width:'  + width  + 'px;'; }
+    if (css.position !== 'absolute') {
+      if (height) { style += 'height:' + height + 'px;'; }
+      if (width)  { style += 'width:'  + width  + 'px;'; }
+    }
 
     for ( var rule in css ){
       if (css.hasOwnProperty(rule)) {


### PR DESCRIPTION
This fill a certain area of the screen with the list view but you'll need to set the width and height of the list view object in `didInsertElement` before calling the super implementation like so:

``` js
  var new_height = parseInt(this.$().css('height'), 10);
  var new_width  = parseInt(this.$().css('width'), 10);
  this.setProperties({ height: new_height, width: new_width });
```
