### PR TITLE
Publish to bower shim for master/beta/release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ node_js:
 script: npm run-script test
 install:
   - "npm install"
+after_success:
+  - ember build --environment production
+  - "./bin/publish_bower_dist"
 env:
   global:
   - S3_BUCKET_NAME=builds.emberjs.com
   - secure: WEQDMFMtTnLhxqUVhQz0xo5i8sHuNcbflQlg8Srak0GKRMEe2Undfexlq0WvpyG/ly/dvJHX/v9pBXPeW0M+3QcqX0XAjLZ/Hwe6Ql5a1PI3vud9oZmYoohVUbwe03RZY52qhPfUkJz8MRU1WifSYKEPvlycl1HmQXWfBPwTsL8=
   - secure: Mp9qNHAwuomZJlC2GAhTAwpfQTHQE9k2JU8C0K81n60UOUsvLArDqDo6kyRUfEHOYihaM8887NuX1yH1Eb7GAupx9C+f6bIhF9sbPWg2ELjf2SHP7RyjJa3uiv5g/KC+bOu61IV1B8/LxEjKpq6SjgOLQFgQDGK/iWK3bI01IrM=
-
+  - secure: "Z91XQe01QmjokC+4iNRUEvfThB5rM7xX+sNlxw5UM25YgKKu/oQyBe7Zo4sNRyPdxuUSpNMpytpl2aF3pFEIFQcq81oBvTl+G2TPXqBMJnG1HtY6lN5Nxi6BsLnC3hPNQoq3d4Pf0ohHz3m06HdYYYY054bYYIbqG1AmGM+lzWU="

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -81,7 +81,13 @@ globalBuild = concat(merge([globalBuild, licenseJS]), {
   outputFile: '/list-view.js'
 });
 
-var distTree = merge([globalBuild, testFiles, testRunner, bower]);
+var bowerShimFiles = pickFiles(__dirname, {
+  srcDir: '/',
+  files: ['bower.json', 'package.json'],
+  destDir: '/'
+});
+
+var distTree = merge([globalBuild, testFiles, testRunner, bower, bowerShimFiles]);
 
 if (env === 'production') {
   var uglified = uglify(globalBuild, { mangle: true });

--- a/bin/publish_bower_dist
+++ b/bin/publish_bower_dist
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+git config --global user.email "tomster@emberjs.com"
+git config --global user.name "Tomster"
+
+# This specifies the repository we are going to work with.  This will most likely be set to 'ember'
+COMPONENTS_EMBER_REPO_SLUG="rondale-sc/list-view-dist"
+
+# This specifies the user who is associated to the GH_TOKEN
+USER="rondale-sc"
+
+# This ensure that no directories within dist will be copied when script is run.
+INCLUDED_FILES=`find dist -maxdepth 1 -type f`
+
+echo -e "COMPONENTS_EMBER_REPO_SLUG: ${COMPONENTS_EMBER_REPO_SLUG}\n"
+echo -e "INCLUDED_FILES: ${INCLUDED_FILES}\n"
+echo -e "CURRENT_BRANCH: ${TRAVIS_BRANCH}\n"
+
+# Set channel to publish to.  If no suitable branch is found exit successfully.
+case $TRAVIS_BRANCH in
+  "master" )
+    CHANNEL="canary" ;;
+  "beta" )
+    CHANNEL="beta" ;;
+  "stable"  )
+    CHANNEL="release" ;;
+  "release" )
+    CHANNEL="release" ;;
+  * )
+    echo "Not a bower release branch.  Exiting!"
+    exit 0 ;;
+esac
+echo -e "CHANNEL: ${CHANNEL}\n"
+
+# sending output to /dev/null to prevent GH_TOKEN leak on error
+git clone --branch ${CHANNEL} https://${USER}:${GH_TOKEN}@github.com/${COMPONENTS_EMBER_REPO_SLUG}.git bower_ember &> /dev/null
+rm -rf bower_ember/*
+cp -r ${INCLUDED_FILES} bower_ember/
+cd bower_ember
+git remote rm origin
+
+# sending output to /dev/null to prevent GH_TOKEN leak on error
+git remote add origin https://${USER}:${GH_TOKEN}@github.com/${COMPONENTS_EMBER_REPO_SLUG}.git &> /dev/null
+git add -A
+git commit -m "List View  Bower Auto build for https://github.com/emberjs/list-view/commits/${TRAVIS_COMMIT}."
+
+# sending output to /dev/null to prevent GH_TOKEN leak on error
+git push -fq origin ${CHANNEL} &> /dev/null
+echo -e "Done\n"


### PR DESCRIPTION
This will publish to [rondale-sc/list-view-dist](https://github.com/rondale-sc/list-view-dist) when the master branch is pushed as the `#canary` branch. 

 I know this is pretty much exactly how emberjs is using it (with channels) and that we don't have a list-view channel system, but I still think this is the best approach (partly to remain consistent).  The `GH_TOKEN` and repo belong to me so this should be good to go out of the box, if you'd like to transfer the dist repo to `emberjs` or `tildeio` we can do that, but it will require that a user who is authenticated with the repo their to set the GH_TOKEN in the `.travis.yml`.

If you'd decide to merge this please let me know a bit beforehand so I can ensure everything is wired up properly.  TY.  

I'll be adding @stefanpenner and @rwjblue as collaborators to list-view-dist so that I'm not the only one with access.  

:heart:
