### PR TITLE
Add support for 1.9 fixes #181

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,10 @@
     "tests"
   ],
   "dependencies": {
-    "ember": "~1.8.0",
+    "ember": "~1.9.0",
     "qunit": "~1.13.0",
     "jquery": "~1.10.x",
-    "handlebars": "~1.3.0"
+    "handlebars": "~2.0.0"
   },
   "devDependencies": {
     "loader.js": "~1.0.0"

--- a/packages/list-view/lib/helper.js
+++ b/packages/list-view/lib/helper.js
@@ -1,4 +1,7 @@
-export default function emberList(options) {
+import EmberListView from './list_view';
+import EmberVirtualListView from './virtual_list_view';
+
+function createHelper (view, options) {
   var hash = options.hash;
   var types = options.hashTypes;
 
@@ -9,8 +12,8 @@ export default function emberList(options) {
   delete types.items;
 
   if (!hash.content) {
-    hash.content = "this";
-    types.content = "ID";
+    hash.content = 'this';
+    types.content = 'ID';
   }
 
   for (var prop in hash) {
@@ -23,5 +26,16 @@ export default function emberList(options) {
     }
   }
 
-  return Ember.Handlebars.helpers.collection.call(this, 'Ember.ListView', options);
-};
+  /*jshint validthis:true */
+  return Ember.Handlebars.helpers.collection.call(this, view, options);
+}
+
+export function EmberList (options) {
+  return createHelper.call(this, EmberListView, options);
+}
+
+export default EmberList;
+
+export function EmberVirtualList (options) {
+  return createHelper.call(this, EmberVirtualListView, options);
+}

--- a/packages/list-view/lib/list_item_view.js
+++ b/packages/list-view/lib/list_item_view.js
@@ -1,4 +1,4 @@
-// jshint validthis: true
+/*jshint validthis:true */
 
 import ListItemViewMixin from 'list-view/list_item_view_mixin';
 

--- a/packages/list-view/lib/list_item_view_mixin.js
+++ b/packages/list-view/lib/list_item_view_mixin.js
@@ -1,6 +1,4 @@
-// jshint validthis: true
-
-var get = Ember.get;
+/*jshint validthis:true */
 
 function samePosition(a, b) {
   return a && b && a.x === b.x && a.y === b.y;
@@ -10,7 +8,7 @@ function positionElement() {
   var element, position, _position;
 
   Ember.instrument('view.updateContext.positionElement', this, function() {
-    element = get(this, 'element');
+    element = this.element;
     position = this.position;
     _position = this._position;
 
@@ -29,14 +27,11 @@ function positionElement() {
   }, this);
 }
 
-export var TransformMixin = Ember.Mixin.create({
-  style: '',
-  attributeBindings: ['style']
-});
-
-export default Ember.Mixin.create(TransformMixin, {
-  _position: null,
+export default Ember.Mixin.create({
   classNames: ['ember-list-item-view'],
+  style: '',
+  attributeBindings: ['style'],
+  _position: null,
   _positionElement: positionElement,
 
   positionElementWhenInserted: Ember.on('init', function(){

--- a/packages/list-view/lib/list_view.js
+++ b/packages/list-view/lib/list_view.js
@@ -1,7 +1,7 @@
 import ListViewHelper from 'list-view/list_view_helper';
 import ListViewMixin from 'list-view/list_view_mixin';
 
-var get = Ember.get, set = Ember.set;
+var get = Ember.get;
 
 /**
   The `Ember.ListView` view class renders a
@@ -109,36 +109,30 @@ export default Ember.ContainerView.extend(ListViewMixin, {
   applyTransform: ListViewHelper.applyTransform,
 
   _scrollTo: function(scrollTop) {
-    var element = get(this, 'element');
+    var element = this.element;
 
     if (element) { element.scrollTop = scrollTop; }
   },
 
   didInsertElement: function() {
     var that = this;
-    var element = get(this, 'element');
 
     this._updateScrollableHeight();
 
     this._scroll = function(e) { that.scroll(e); };
 
-    Ember.$(element).on('scroll', this._scroll);
+    Ember.$(this.element).on('scroll', this._scroll);
   },
 
   willDestroyElement: function() {
-    var element;
-
-    element = get(this, 'element');
-
-    Ember.$(element).off('scroll', this._scroll);
+    Ember.$(this.element).off('scroll', this._scroll);
   },
 
   scroll: function(e) {
     this.scrollTo(e.target.scrollTop);
   },
 
-  scrollTo: function(y){
-    var element = get(this, 'element');
+  scrollTo: function(y) {
     this._scrollTo(y);
     this._scrollContentTo(y);
   },

--- a/packages/list-view/lib/list_view_mixin.js
+++ b/packages/list-view/lib/list_view_mixin.js
@@ -1,12 +1,14 @@
-// jshint validthis: true
+/*jshint validthis:true */
 
 import ReusableListItemView from 'list-view/reusable_list_item_view';
 
-var get = Ember.get, set = Ember.set,
-
-min = Math.min, max = Math.max, floor = Math.floor,
-ceil = Math.ceil,
-forEach = Ember.ArrayPolyfills.forEach;
+var get     = Ember.get;
+var set     = Ember.set;
+var min     = Math.min;
+var max     = Math.max;
+var floor   = Math.floor;
+var ceil    = Math.ceil;
+var forEach = Ember.ArrayPolyfills.forEach;
 
 function addContentArrayObserver() {
   var content = get(this, 'content');
@@ -26,12 +28,6 @@ function syncChildViews() {
 
 function sortByContentIndex (viewOne, viewTwo) {
   return get(viewOne, 'contentIndex') - get(viewTwo, 'contentIndex');
-}
-
-function notifyMutationListeners() {
-  if (Ember.View.notifyMutationListeners) {
-    Ember.run.once(Ember.View, 'notifyMutationListeners');
-  }
 }
 
 function removeEmptyView() {
@@ -66,11 +62,11 @@ function addEmptyView() {
 }
 
 function enableProfilingOutput() {
-  function before(name, time, payload) {
+  function before(name, time/*, payload*/) {
     console.time(name);
   }
 
-  function after (name, time, payload) {
+  function after (name, time/*, payload*/) {
     console.timeEnd(name);
   }
 
@@ -138,21 +134,26 @@ export default Ember.Mixin.create({
     @method render
     @param {Ember.RenderBuffer} buffer The render buffer
   */
-  render: function(buffer) {
-    buffer.push('<div class="ember-list-container"></div>');
-    this._super(buffer);
+  render: function (buffer) {
+    var element          = buffer.element();
+    var dom              = buffer.dom;
+    var container        = dom.createElement('div');
+    container.className  = 'ember-list-container';
+    element.appendChild(container);
+
+    this._childViewsMorph = dom.createMorph(container, container, null);
+
+    return container;
   },
 
   createChildViewsMorph: function (element) {
-    var children = element.children;
-    element = children[0];
-    this._childViewsMorph = this._renderer._dom.createMorph(element, children[children.length - 1], null);
+    this._childViewsMorph = this._renderer._dom.createMorph(element.lastChild, element.lastChild, null);
     return element;
   },
 
   willInsertElement: function() {
-    if (!this.get("height") || !this.get("rowHeight")) {
-      throw new Error("A ListView must be created with a height and a rowHeight.");
+    if (!this.get('height') || !this.get('rowHeight')) {
+      throw new Error('A ListView must be created with a height and a rowHeight.');
     }
     this._super();
   },
@@ -329,6 +330,10 @@ export default Ember.Mixin.create({
     childView.prepareForReuse();
   },
 
+  createChildView: function (_view) {
+    return this._super(_view, this._itemViewProps || {});
+  },
+
   /**
     @private
     @method _reuseChildForContentIndex
@@ -341,16 +346,14 @@ export default Ember.Mixin.create({
     if (childView.constructor !== contentViewClass) {
       // rather then associative arrays, lets move childView + contentEntry maping to a Map
       var i = this._childViews.indexOf(childView);
-
       childView.destroy();
       childView = this.createChildView(contentViewClass);
-
       this.insertAt(i, childView);
     }
 
-    content = get(this, 'content');
+    content         = get(this, 'content');
     enableProfiling = get(this, 'enableProfiling');
-    position = this.positionForIndex(contentIndex);
+    position        = this.positionForIndex(contentIndex);
     childView.updatePosition(position);
 
     set(childView, 'contentIndex', contentIndex);
@@ -477,7 +480,7 @@ export default Ember.Mixin.create({
     currentScrollTop = this.scrollTop;
     newColumnCount = get(this, 'columnCount');
     maxScrollTop = get(this, 'maxScrollTop');
-    element = get(this, 'element');
+    element = this.element;
 
     this._lastColumnCount = newColumnCount;
 
@@ -637,9 +640,7 @@ export default Ember.Mixin.create({
     @event contentWillChange
   */
   contentWillChange: Ember.beforeObserver(function() {
-    var content;
-
-    content = get(this, 'content');
+    var content = get(this, 'content');
 
     if (content) {
       content.removeArrayObserver(this);
@@ -670,12 +671,11 @@ export default Ember.Mixin.create({
     @param {Number} contentIndex item index in the content array
     @method _addItemView
   */
-  _addItemView: function(contentIndex){
+  _addItemView: function (contentIndex) {
     var itemViewClass, childView;
 
     itemViewClass = this.itemViewForIndex(contentIndex);
     childView = this.createChildView(itemViewClass);
-
     this.pushObject(childView);
   },
 
@@ -714,13 +714,13 @@ export default Ember.Mixin.create({
 
     @method _syncChildViews
    **/
-  _syncChildViews: function(){
+  _syncChildViews: function () {
     var childViews, childViewCount,
         numberOfChildViews, numberOfChildViewsNeeded,
         contentIndex, startingIndex, endingIndex,
         contentLength, emptyView, count, delta;
 
-    if (get(this, 'isDestroyed') || get(this, 'isDestroying')) {
+    if (this.isDestroyed || this.isDestroying) {
       return;
     }
 
@@ -800,18 +800,18 @@ export default Ember.Mixin.create({
         contentIndex, visibleEndingIndex, maxContentIndex,
         contentIndexEnd, scrollTop;
 
-    scrollTop = this.scrollTop;
-    contentLength = get(this, 'content.length');
-    maxContentIndex = max(contentLength - 1, 0);
-    childViews = this.getReusableChildViews();
-    childViewsLength =  childViews.length;
+    scrollTop          = this.scrollTop;
+    contentLength      = get(this, 'content.length');
+    maxContentIndex    = max(contentLength - 1, 0);
+    childViews         = this.getReusableChildViews();
+    childViewsLength   =  childViews.length;
 
-    startingIndex = this._startingIndex();
+    startingIndex      = this._startingIndex();
     visibleEndingIndex = startingIndex + this._numChildViewsForViewport();
 
-    endingIndex = min(maxContentIndex, visibleEndingIndex);
+    endingIndex        = min(maxContentIndex, visibleEndingIndex);
 
-    contentIndexEnd = min(visibleEndingIndex, startingIndex + childViewsLength);
+    contentIndexEnd    = min(visibleEndingIndex, startingIndex + childViewsLength);
 
     for (contentIndex = startingIndex; contentIndex < contentIndexEnd; contentIndex++) {
       childView = childViews[contentIndex % childViewsLength];
@@ -846,7 +846,7 @@ export default Ember.Mixin.create({
     var index, contentIndex, state;
 
     if (this._isChildEmptyView()) {
-        removeEmptyView.call(this);
+      removeEmptyView.call(this);
     }
 
     // Support old and new Ember versions

--- a/packages/list-view/lib/main.js
+++ b/packages/list-view/lib/main.js
@@ -1,7 +1,7 @@
 import ReusableListItemView from 'list-view/reusable_list_item_view';
 import VirtualListView from 'list-view/virtual_list_view';
 import ListItemView from 'list-view/list_item_view';
-import EmberList from 'list-view/helper';
+import { EmberList, EmberVirtualList } from 'list-view/helper';
 import ListView from 'list-view/list_view';
 import ListViewHelper from 'list-view/list_view_helper';
 
@@ -12,3 +12,4 @@ Ember.ListView             = ListView;
 Ember.ListViewHelper       = ListViewHelper;
 
 Ember.Handlebars.registerHelper('ember-list', EmberList);
+Ember.Handlebars.registerHelper('ember-virtual-list', EmberVirtualList);

--- a/packages/list-view/lib/reusable_list_item_view.js
+++ b/packages/list-view/lib/reusable_list_item_view.js
@@ -3,20 +3,24 @@ import ListItemViewMixin from 'list-view/list_item_view_mixin';
 var get = Ember.get, set = Ember.set;
 
 export default Ember.View.extend(ListItemViewMixin, {
-  init: function(){
+  prepareForReuse: Ember.K,
+
+  init: function () {
     this._super();
     var context = Ember.ObjectProxy.create();
     this.set('context', context);
     this._proxyContext = context;
   },
-  isVisible: Ember.computed('context.content', function(){
+
+  isVisible: Ember.computed('context.content', function () {
     return !!this.get('context.content');
   }),
-  updateContext: function(newContext){
-    var context = get(this._proxyContext, 'content'), state;
+
+  updateContext: function (newContext) {
+    var context = get(this._proxyContext, 'content');
 
     // Support old and new Ember versions
-    state = this._state || this.state;
+    var state = this._state || this.state;
 
     if (context !== newContext) {
       if (state === 'inDOM') {
@@ -29,6 +33,5 @@ export default Ember.View.extend(ListItemViewMixin, {
         set(this, 'controller', newContext);
       }
     }
-  },
-  prepareForReuse: Ember.K
+  }
 });

--- a/packages/list-view/lib/virtual_list_scroller_events.js
+++ b/packages/list-view/lib/virtual_list_scroller_events.js
@@ -1,4 +1,5 @@
-// jshint validthis: true
+/*jshint validthis:true */
+
 var fieldRegex = /input|textarea|select/i,
   hasTouch = ('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch,
   handleStart, handleMove, handleEnd, handleCancel,

--- a/packages/list-view/lib/virtual_list_view.js
+++ b/packages/list-view/lib/virtual_list_view.js
@@ -6,7 +6,7 @@ import ListViewMixin from 'list-view/list_view_mixin';
 import ListViewHelper from 'list-view/list_view_helper';
 import VirtualListScrollerEvents from 'list-view/virtual_list_scroller_events';
 
-var max = Math.max, get = Ember.get, set = Ember.set;
+var get = Ember.get;
 
 function updateScrollerDimensions(target) {
   var width, height, totalHeight;
@@ -44,11 +44,9 @@ export default Ember.ContainerView.extend(ListViewMixin, VirtualListScrollerEven
   applyTransform: ListViewHelper.apply3DTransform,
 
   setupScroller: function(){
-    var view, y;
+    var view = this;
 
-    view = this;
-
-    view.scroller = new Scroller(function(left, top, zoom) {
+    view.scroller = new Scroller(function(left, top/*, zoom*/) {
       // Support old and new Ember versions
       var state = view._state || view.state;
 
@@ -87,7 +85,7 @@ export default Ember.ContainerView.extend(ListViewMixin, VirtualListScrollerEven
 
     this.pullToRefreshView.on('didInsertElement', function() {
       Ember.run.scheduleOnce('afterRender', this, function(){
-        view.applyTransform(get(this, 'element'), 0, -1 * view.pullToRefreshViewHeight);
+        view.applyTransform(this.element, 0, -1 * view.pullToRefreshViewHeight);
       });
     });
   },


### PR DESCRIPTION
- Adding support for 1.9 (still works with 1.8.x)
- Removed deadcode/variables (lots more.. but holding off until the pack PR is merged)
- Removed Ember.get around `this.element`
