### PR TITLE
fix click events re-propogation on mobile

### DIFF
--- a/packages/list-view/lib/virtual_list_scroller_events.js
+++ b/packages/list-view/lib/virtual_list_scroller_events.js
@@ -135,7 +135,7 @@ function synthesizeClick(e) {
   var point = e.changedTouches[0],
     target = point.target,
     ev;
-  if (target && fieldRegex.test(target.tagName)) {
+  if (target && !fieldRegex.test(target.tagName)) {
     ev = document.createEvent('MouseEvents');
     ev.initMouseEvent('click', true, true, e.view, 1, point.screenX, point.screenY, point.clientX, point.clientY, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey, 0, null);
     return target.dispatchEvent(ev);


### PR DESCRIPTION
fixes GH-170

Previously, we did not fire a click event for touch events
on mobile unless the event target was a form field. This is
incorrect as the event was not `preventDefault`'d before.

As you can see on Lines 48-50 in https://github.com/emberjs/list-view/blob/0e596c9c629fa076e9089e787bb2e360b8efccb6/packages/list-view/lib/virtual_list_scroller_events.js#L48-50 (not the commit
that introduced the bug, just a hard link reference),
the "begin scroll" handler does not preventDefault
on the event if it is a form field, so we do not need
 to re-propogate it in `synthesizeClick`.

All other tag types *do* need to synthesize the click
event on mobile however.

I ran the tests in the XCode simulator and they passed.