### PR TITLE
exclude dev assets in prod

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,11 @@ module.exports = {
   name: 'list-view',
   treeForVendor: function() {
 
+    if(!this.isDevelopingAddon()) {
+      return;
+    }
+
+
     var klassy = new this.Funnel('bower_components', {
       srcDir: '/klassy/lib',
       files: ['klassy.js'],


### PR DESCRIPTION
this is an fix to go along with ember-js/list-view#204 so that klassy and other development addons are excluded when list-view addon is exposed.