### PR TITLE
delete deprecated beforeobserver

### DIFF
--- a/addon/list-view-mixin.js
+++ b/addon/list-view-mixin.js
@@ -121,8 +121,14 @@ export default Ember.Mixin.create({
     this._addContentArrayObserver();
   },
 
-  _addContentArrayObserver: Ember.beforeObserver(function() {
+  _addContentArrayObserver: Ember.observer(function () {
+    var content    = get(this, 'content');
+    var oldContent = get(this, 'oldContent');
+
+    if (oldContent === content) { return; }
+
     addContentArrayObserver.call(this);
+    set(this, 'oldContent', content);
   }, 'content'),
 
   /**
@@ -640,12 +646,15 @@ export default Ember.Mixin.create({
     @private
     @event contentWillChange
   */
-  contentWillChange: Ember.beforeObserver(function() {
-    var content = get(this, 'content');
+  contentWillChange: Ember.observer(function() {
+    var content  = get(this, 'content');
+    if (!content) { return; }
 
-    if (content) {
-      content.removeArrayObserver(this);
-    }
+    var oldContent = get(this, 'oldContent');
+    if (oldContent === content) { return; }
+
+    content.removeArrayObserver(this);
+    set(this, 'oldContent', content);
   }, 'content'),
 
   /**),


### PR DESCRIPTION
Before observers are deprecated due to the negative performance implications they have for Ember internals and applications.

http://emberjs.com/deprecations/v1.x/#toc_beforeobserver