### PR TITLE
Updated documentation to reference {{collection}} helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ ember install:addon ember-list-view
 
 First, let's create a template:
 ```handlebars
-{{#view 'list-view' items=model height=500 rowHeight=50 width=500}}
+{{#ember-list items=model height=500 row-height=50 width=500}}
   {{name}}
-{{/view}}
+{{/ember-list}}
 ```
 
 Next, let's feed our template with some data:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ export default ListView.extend({
 Use the `{{collection}}` helper in your template.
 
 ```handlebars
-{{collection 'my-list' items=model}}
+{{collection 'my-list' content=model}}
 ```
 
 Create a **my-list-item.hbs** in your project's **/templates** directory.

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ export default ListView.extend({
 });
 ```
 
-Use the `{{view}}` helper in your template.
+Use the `{{collection}}` helper in your template.
 
 ```handlebars
-{{view 'my-list' items=model}}
+{{collection 'my-list' items=model}}
 ```
 
 Create a **my-list-item.hbs** in your project's **/templates** directory.

--- a/tests/acceptance/collection-helper-test.js
+++ b/tests/acceptance/collection-helper-test.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+  } from 'qunit';
+import startApp from '../helpers/start-app';
+
+var application;
+
+module('Acceptance: Collection Helper', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('collection helper renders list view', function(assert) {
+  visit('/collection-helper');
+  andThen(function() {
+    assert.equal(currentURL(), '/collection-helper');
+    assert.equal(find('.ember-list-item-view').length, 18, "18 rows are visible");
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
   this.route('pull-to-refresh');
   this.route('virtual');
   this.route('virtual-strange-ratios');
+  this.route('collection-helper');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/collection-helper.js
+++ b/tests/dummy/app/routes/collection-helper.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import makeModel from '../utils/make-model';
+
+export default Ember.Route.extend({
+  model: makeModel()
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -10,5 +10,6 @@
     <li>{{#link-to 'pull-to-refresh'}}Pull to refresh{{/link-to}}</li>
     <li>{{#link-to 'virtual'}}Virtual{{/link-to}}</li>
     <li>{{#link-to 'virtual-strange-ratios'}}Virtual Strange Ratios{{/link-to}}</li>
+    <li>{{#link-to 'collection-helper'}}Collection Helper{{/link-to}}</li>
 </ul>
 {{outlet}}

--- a/tests/dummy/app/templates/collection-helper.hbs
+++ b/tests/dummy/app/templates/collection-helper.hbs
@@ -1,0 +1,7 @@
+<h3>Collection Helper</h3>
+
+<div class="collection-helper">
+    {{#collection 'list-view' content=model height=500 rowHeight=30}}
+      {{name}}
+    {{/collection}}
+</div>


### PR DESCRIPTION
- {{view}} helper doesn't seem to work with list-view
- verified that {{collection}} helper works with list-view
- added acceptance test for {{collection}} view to show that it works
- updated documentation to use `{{ember-list}}` where `{{#view}}{{/view}}` was used

Do we need {{view}} helper? Can we just use {{collection}}?

Related: #227 
