### PR TITLE
applyTransform should also use translate3d

### DIFF
--- a/addon/list-view-helper.js
+++ b/addon/list-view-helper.js
@@ -76,7 +76,9 @@ function setStyle (optionalStyleString) {
 export default {
   transformProp: transformProp,
   applyTransform: (function () {
-    if (supports2D) {
+    if (supports3D) {
+      return setStyle('translate3d(%@px, %@px, 0)');
+    } else if (supports2D) {
       return setStyle('translate(%@px, %@px)');
     }
 


### PR DESCRIPTION
As a performance optimization on some mobile browsers, use translate3d if device supports3d.. Currently this is only done on apply3DTransform which is only used by VirtualListView. The standard ListView should also do the same logic...