### PR TITLE
Fixed installation instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It would help us greatly to help you and to improve ember list view.
 Install *ListView* with EmberCLI using this command.
 
 ```bash
-ember install:addon ember-list-view
+ember install ember-list-view
 ```
 
 ## Usage


### PR DESCRIPTION
ember-cli install:addon has been removed in favor of ember-cli install

https://github.com/ember-cli/ember-cli/issues/3204